### PR TITLE
recovery: Bypass reboot prompt for sideload-auto-reboot

### DIFF
--- a/install/install.cpp
+++ b/install/install.cpp
@@ -587,7 +587,7 @@ static InstallResult TryUpdateBinary(Package* package, bool* wipe_cache,
   if (package_is_ab) {
     ab_package_installed = true;
     PerformPowerwashIfRequired(zip, device);
-    if (ask_to_ab_reboot(device)) {
+    if (!ui->IsSideloadAutoReboot() && ask_to_ab_reboot(device)) {
       reboot_to_recovery();
     }
   }

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -960,6 +960,7 @@ Device::BuiltinAction start_recovery(Device* device, const std::vector<std::stri
     if (!sideload_auto_reboot) {
       ui->ShowText(true);
     }
+    ui->SetSideloadAutoReboot(sideload_auto_reboot);
     status = ApplyFromAdb(device, false /* rescue_mode */, &next_action);
     ui->Print("\nInstall from ADB complete (status: %d).\n", status);
     if (sideload_auto_reboot) {

--- a/recovery_ui/include/recovery_ui/ui.h
+++ b/recovery_ui/include/recovery_ui/ui.h
@@ -297,6 +297,14 @@ class RecoveryUI {
     EnqueueKey(KEY_REFRESH);
   }
 
+  bool IsSideloadAutoReboot() const {
+    return sideload_auto_reboot_;
+  }
+
+  void SetSideloadAutoReboot(bool sar) {
+    sideload_auto_reboot_ = sar;
+  }
+
  protected:
   void EnqueueKey(int key_code);
   void EnqueueTouch(const Point& pos);
@@ -313,6 +321,8 @@ class RecoveryUI {
   bool touch_screen_allowed_;
 
   bool fastbootd_logo_enabled_;
+
+  bool sideload_auto_reboot_;
 
  private:
   enum class ScreensaverState {

--- a/recovery_ui/ui.cpp
+++ b/recovery_ui/ui.cpp
@@ -64,6 +64,7 @@ RecoveryUI::RecoveryUI()
       max_brightness_file_(MAX_BRIGHTNESS_FILE),
       touch_screen_allowed_(true),
       fastbootd_logo_enabled_(false),
+      sideload_auto_reboot_(false),
       touch_low_threshold_(android::base::GetIntProperty("ro.recovery.ui.touch_low_threshold",
                                                          kDefaultTouchLowThreshold)),
       touch_high_threshold_(android::base::GetIntProperty("ro.recovery.ui.touch_high_threshold",


### PR DESCRIPTION
When we want to automatically reboot after a sideload, it doesn't make much sense to try and prompt the user for a reboot into recovery.

Change-Id: Id0195965362b62bf940caba1f83ffe12191a73c6